### PR TITLE
introduce resolver 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["rust", "rust/derive", "rust/test_helpers"]
 default-members = ["rust", "rust/derive", "rust/test_helpers"]
+resolver = "2"
 
 [workspace.package]
 authors = ["Dr Maxim Orlovsky <orlovsky@ubideco.org>"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["derive", "test_helpers"]
 
 [dependencies]
 amplify = { version = "4.0.0", features = ["proc_attr"] }
-strict_encoding_derive = { version = "2.0.0", path = "derive", optional = true }
+strict_encoding_derive = { version = "2.0.0", path = "derive" }
 half = { version = "2.1.0", optional = true }
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
 
@@ -33,9 +33,7 @@ all = [
     "derive",
     "serde"
 ]
-derive = [
-    "strict_encoding_derive"
-]
+derive = []
 float = [
     "amplify/apfloat",
     "half"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -31,9 +31,13 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "derive")]
-pub extern crate strict_encoding_derive as derive;
-#[cfg(feature = "derive")]
 pub use derive::{StrictDecode, StrictDumb, StrictEncode, StrictType};
+#[cfg(not(feature = "derive"))]
+use derive::{StrictDecode, StrictDumb, StrictEncode, StrictType};
+#[cfg(feature = "derive")]
+pub use strict_encoding_derive as derive;
+#[cfg(not(feature = "derive"))]
+use strict_encoding_derive as derive;
 
 #[macro_use]
 extern crate amplify;


### PR DESCRIPTION
Closes https://github.com/strict-types/strict-encoding/issues/19

`strict_encoding_derive` is not optional since primitive strict types such as [U4](https://github.com/strict-types/strict-encoding/blob/19fb7b0bd23108ca4ca540bfe80fb49e5684b169/rust/src/stl.rs#L86) derives `StrictType` and so on.